### PR TITLE
Update chart to use new repo

### DIFF
--- a/k8s/workloads/refractr/refractr-ingress.yaml
+++ b/k8s/workloads/refractr/refractr-ingress.yaml
@@ -8,16 +8,16 @@
 apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
-  name: nginx-ingress
+  name: ingress-nginx
   namespace: refractr-prod
   labels:
     app: refractr
 spec:
-  releaseName: refractr-nginx-ingress
+  releaseName: refractr-ingress-nginx
   chart:
-    repository: https://kubernetes-charts.storage.googleapis.com
-    name: nginx-ingress
-    version: "1.31.0"
+    repository: https://kubernetes.github.io/ingress-nginx
+    name: ingress-nginx
+    version: "2.16.0"
   values:
     controller:
       useIngressClassOnly: true


### PR DESCRIPTION
Replace nginx ingress controller with `ingress-nginx/ingress-nginx` since the `stable/nginx-ingress` repo has been deprecated