### PR TITLE
Add EIP for ingress-nginx

### DIFF
--- a/k8s/workloads/refractr/refractr-ingress.yaml
+++ b/k8s/workloads/refractr/refractr-ingress.yaml
@@ -33,6 +33,9 @@ spec:
       service:
         annotations:
           service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+          # not really well documented except for this here:
+          # https://github.com/kubernetes/kubernetes/issues/63959
+          service.beta.kubernetes.io/aws-load-balancer-eip-allocations: "eipalloc-0e9eb2d9f63a68ab8,eipalloc-0f4a591198b52e017,eipalloc-06d4150517deeeef7"
       metrics:
         enabled: true
     rbac:

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -3,6 +3,11 @@ data "aws_vpc" "this" {
   id = data.terraform_remote_state.vpc.outputs.vpc_id
 }
 
+data "aws_subnet" "public" {
+  for_each = toset(data.terraform_remote_state.vpc.outputs.public_subnets)
+  id       = each.value
+}
+
 data "aws_eks_cluster" "itse-apps-prod-1" {
   name = module.itse-apps-prod-1.cluster_id
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -5,6 +5,15 @@ output "cluster_id" {
 output "cluster_oidc_issuer_url" {
   value = module.itse-apps-prod-1.cluster_oidc_issuer_url
 }
+
 output "cluster_name" {
   value = module.itse-apps-prod-1.cluster_id
+}
+
+output "refractr_eip_allocation_id" {
+  value = aws_eip.refractr_eip.*.id
+}
+
+output "refractr_ips" {
+  value = aws_eip.refractr_eip.*.public_ip
 }


### PR DESCRIPTION
Add a static EIP to the ingress-nginx nlb, this removes the need for global accelerator