### PR TITLE
Update external-dns to only check service as a source

### DIFF
--- a/terraform/external-dns.tf
+++ b/terraform/external-dns.tf
@@ -4,11 +4,15 @@ locals {
 
   external_dns_chart_settings = {
     "provider"                                                  = "aws"
-    "policy"                                                    = "upsert-only"
+    "policy"                                                    = "sync"
     "replicas"                                                  = "1"
     "metrics.enabled"                                           = "true"
     "txtOwnerId"                                                = "${module.itse-apps-prod-1.cluster_id}-${random_string.string.result}"
     "serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn" = module.external_dns_role.this_iam_role_arn
+    # NOTE: The default option for this is actually ['service', 'ingress'] where external-dns
+    # crates DNS Records based on the hosts specified in the ingress object. This is less than ideal
+    # so we just configure it to check the service annotation instead
+    "sources[0]" = "service"
   }
 
   external_dns_tags = {


### PR DESCRIPTION
Configure `external-dns` to only check `service` as a source. We're removing `ingress` as a source because it checks
the lists of host in the ingress object and create dns records based on that. This is less than ideal for our
situation