### PR TITLE
Add Pastebin Prod Deployment

### DIFF
--- a/k8s/namespaces/pastebin-prod.yaml
+++ b/k8s/namespaces/pastebin-prod.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: pastebin-prod

--- a/k8s/releases/pastebin/pastebin.yaml
+++ b/k8s/releases/pastebin/pastebin.yaml
@@ -1,0 +1,80 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: pastebin
+  namespace: pastebin-prod
+  labels:
+    app: pastebin
+  annotations:
+    fluxcd.io/automated: "true"
+    filter.fluxcd.io/chart-image: regex:^(v[0-9]+.[0-9]+.[0-9]+)$
+spec:
+  releaseName: pastebin
+  chart:
+    repository: https://mozilla-it.github.io/helm-charts/
+    name: pastebin
+    version: "0.1.1"
+  values:
+    configMap:
+      data:
+        DB_PORT: "3306"
+        VAL: "5"
+    deployment:
+      port: "8000"
+      replicaCount: "1"
+    externalSecrets:
+      enabled: true
+      name: pastebin
+      secrets:
+      - key: /prod/pastebin/envvar
+        name: DB_HOST
+        property: database_host
+      - key: /prod/pastebin/envvar
+        name: DB_NAME
+        property: database_name
+      - key: /prod/pastebin/envvar
+        name: DB_PASS
+        property: database_password
+      - key: /prod/pastebin/envvar
+        name: DB_USER
+        property: database_user
+      - key: /prod/pastebin/envvar
+        name: SESSION_KEY
+        property: session_key
+    image:
+      pullPolicy: Always
+      tag: v3.5.4
+    ingress:
+      hosts:
+        - host: paste.prod.mozit.cloud
+          paths:
+            - path: /
+              pathType: ImplementationSpecific
+              serviceName: pastebin
+              servicePort: 80
+        - host: paste.mozilla.org
+          paths:
+            - path: /
+              pathType: ImplementationSpecific
+              serviceName: pastebin
+              servicePort: 80
+        - host: pastebin.mozilla.org
+          paths:
+            - path: /
+              pathType: ImplementationSpecific
+              serviceName: pastebin
+              servicePort: 80
+      le:
+        name: prod
+      name: pastebin
+      tls:
+        - hosts:
+            - paste.mozilla.org
+          secretName: cert-paste-mozilla-org
+        - hosts:
+            - pastebin.mozilla.org
+          secretName: cert-pastebin-mozilla-org
+        - hosts:
+            - paste.prod.mozit.cloud
+          secretName: cert-paste-prod-mozit-cloud

--- a/k8s/workloads/pastebin/pastebin-ingress.yaml
+++ b/k8s/workloads/pastebin/pastebin-ingress.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: ingress-nginx
+  namespace: pastebin-prod
+  labels:
+    app: pastebin
+spec:
+  releaseName: pastebin-ingress-nginx
+  chart:
+    repository: https://kubernetes.github.io/ingress-nginx
+    name: ingress-nginx
+    version: "3.33.0"
+  values:
+    controller:
+      useIngressClassOnly: true
+      enableCustomResources: false
+      autoscaling:
+        enabled: true
+        minReplicas: 1
+        maxReplicas: 4
+        targetCPUUtilizationPercentage: 80
+        targetMemoryUtilizationPercentage: 80
+      resources:
+        requests:
+          cpu: 200m
+          memory: 512Mi
+        limits:
+          cpu: 512m
+          memory: 1Gi
+      admissionWebhooks:
+        enable: false
+      scope:
+        enabled: true
+      config:
+        use-proxy-protocol: "false"
+        use-forwarded-headers: "true"
+        # restrict this to the IP addresses of ELB
+        proxy-real-ip-cidr: "0.0.0.0/0"
+      service:
+        externalTrafficPolicy: "Local"
+        annotations:
+          service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+          service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
+          service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled: "true"
+          service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: "Environment=prod"
+          external-dns.alpha.kubernetes.io/hostname: "paste.prod.mozit.cloud"
+      metrics:
+        enabled: true
+        service:
+          annotations:
+            prometheus.io/scrape: "true"
+            prometheus.io/port: "10254"
+    rbac:
+      create: true
+      scope: true


### PR DESCRIPTION
Jira Ticket: https://mozilla-hub.atlassian.net/browse/SE-2104

What this PR does:
* Setups Pastebin production deployment on the new cluster - ingress-nginx helm release, namespace, & application helm-release

Notes:
* It will not conflict with paste.mozilla.org (e.g. current production), as its running on an entirely different cluster & we don't need to swap the DNS record to this cluster's deployment until ready
* Requires the infrastructure on #47 
* Database is able to connect to both old cluster deployment & new cluster deployment, which also share the same schemas for both versions of the application, so an easy roll-over is feasible via DNS records only when ready