### PR TITLE
try explicitly adding image repo to pastebin helmrelease for flux

### DIFF
--- a/k8s/releases/pastebin/pastebin.yaml
+++ b/k8s/releases/pastebin/pastebin.yaml
@@ -45,6 +45,7 @@ spec:
         property: session_key
     image:
       pullPolicy: Always
+      repository: 783633885093.dkr.ecr.us-west-2.amazonaws.com/pastebin
       tag: v3.5.5
     ingress:
       hosts:


### PR DESCRIPTION
Jira: https://mozilla-hub.atlassian.net/browse/SE-2225

What this PR does:
* adds repository field to pastebin prod helmrelease, as we think that field has to be in the helmrelease values block (not just the default in the used helm chart Values) to be picked up by flux