### PR TITLE
migrate here the moderator-devs AWS IAM Role & mozillians group setup in case helpful

### DIFF
--- a/terraform/applications/moderator/iam.tf
+++ b/terraform/applications/moderator/iam.tf
@@ -4,6 +4,7 @@
 data "aws_iam_policy_document" "ecr_rw" {
   statement {
     actions = [
+      "ecr:DescribeImages",
       "ecr:GetAuthorizationToken",
     ]
 
@@ -17,7 +18,6 @@ data "aws_iam_policy_document" "ecr_rw" {
       "ecr:GetRepositoryPolicy",
       "ecr:DescribeRepositories",
       "ecr:ListImages",
-      "ecr:DescribeImages",
       "ecr:BatchGetImage",
       "ecr:InitiateLayerUpload",
       "ecr:UploadLayerPart",

--- a/terraform/applications/moderator/iam.tf
+++ b/terraform/applications/moderator/iam.tf
@@ -1,0 +1,49 @@
+#
+# Moderator Developers ECR Read/Write Access Policy
+#
+data "aws_iam_policy_document" "ecr_rw" {
+  statement {
+    actions = [
+      "ecr:GetAuthorizationToken",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    actions = [
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:GetRepositoryPolicy",
+      "ecr:DescribeRepositories",
+      "ecr:ListImages",
+      "ecr:DescribeImages",
+      "ecr:BatchGetImage",
+      "ecr:InitiateLayerUpload",
+      "ecr:UploadLayerPart",
+      "ecr:CompleteLayerUpload",
+      "ecr:PutImage",
+    ]
+
+    resources = [
+      module.ecr.ecr_arn,
+    ]
+  }
+}
+
+resource "aws_iam_policy" "ecr_rw" {
+  name        = "policy"
+  description = "Allow users & roles to push new Moderator ECR images"
+  path        = "/moderator/"
+  policy      = data.aws_iam_policy_document.ecr_rw.json
+}
+
+#
+#   Moderator Developers Role & Permissions Setup
+#
+module "moderator_devs" {
+  source       = "github.com/mozilla-it/terraform-modules//aws/maws-roles?ref=master"
+  role_name    = "moderator-devs"
+  role_mapping = ["mozilliansorg_mozilla-moderator-devs"]
+  policy_arn   = [aws_iam_policy.ecr_rw.arn]
+}


### PR DESCRIPTION
Jira Ticket: https://mozilla-hub.atlassian.net/browse/SE-2168

What this PR does:
* migrates the moderator-devs AWS role / mozillians group setup to this terraform
* was originally setup just for ECR access (relevant to old deployment pattern), but keeping around without changing bc I could see this group being helpful in the future for different permissions
* moving from mozilla-it/moderator-infra, which i'm working on decommissioning now