### PR TITLE
SE-2452 Add prometheus exporting to influxdb

### DIFF
--- a/terraform/shared/main.tf
+++ b/terraform/shared/main.tf
@@ -6,6 +6,7 @@ locals {
     "flux"               = true
     "flux_helm_operator" = true
     "prometheus"         = true
+    "configmapsecrets"   = true
   }
 
   external_secrets_settings = {
@@ -49,6 +50,14 @@ module "itse-apps-prod-1" {
   flux_settings               = local.flux_settings
   node_groups                 = local.node_groups
   vpc_id                      = data.terraform_remote_state.vpc.outputs.vpc_id
+  prometheus_settings = {
+    "server.persistentVolume.size" : "50Gi"
+  }
+  prometheus_customization_settings = {
+    "influxdb.enabled" : "true"
+    "influxdb.secret_key" : "/prod/influxdb/prod"
+  }
+  influxdb = true
 }
 
 # Chicken and egg issue, this needs to exist first


### PR DESCRIPTION
Increased disk space because the deployment was initially failing with running out of space. I was able to see we were using 84% on the other disk so figured we might as well give ourselves a little more headroom.

Example metrics flowing to Influxdb:
![Screenshot 2021-08-17 at 16-39-02 New dashboard - Grafana](https://user-images.githubusercontent.com/1072933/129804170-1a321bb8-a753-4989-a0bf-880c59b122c1.png)
