### PR TITLE
update discourse prod helmrelease to filter on new CI tags

### DIFF
--- a/k8s/releases/discourse/discourse.yaml
+++ b/k8s/releases/discourse/discourse.yaml
@@ -9,7 +9,7 @@ metadata:
     env: prod
   annotations:
     fluxcd.io/automated: "true"
-    filter.fluxcd.io/chart-image: regex:^(prod-[a-f0-9]{7}-[0-9]*)$
+    filter.fluxcd.io/chart-image: regex:^(prod-v[0-9]+.[0-9]+.[0-9]+)$
 spec:
   releaseName: discourse-prod
   chart:


### PR DESCRIPTION
Jira ticket: https://mozilla-hub.atlassian.net/browse/SE-2091

What this PR does:
* with discourse' updated CI in place (https://github.com/mozilla/discourse.mozilla.org/pull/43) this updates prod discourse helmrelease to watch for the updated docker image tag applied by CI (prod-v1.2.3)