### PR TITLE
update DNS for discourse prod

### DIFF
--- a/k8s/workloads/discourse/discourse-ingress-prod.yaml
+++ b/k8s/workloads/discourse/discourse-ingress-prod.yaml
@@ -55,7 +55,7 @@ spec:
           service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
           service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled: "true"
           service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: "Environment=prod"
-          external-dns.alpha.kubernetes.io/hostname: "discourse.prod.mozit.cloud"
+          external-dns.alpha.kubernetes.io/hostname: "discourse.prod.mozit.cloud,discourse.mozilla.org"
       metrics:
         enabled: true
         service:


### PR DESCRIPTION
Jira: https://mozilla-hub.atlassian.net/browse/SE-2172

What this PR does:
* adds discourse.mozilla.org to external-dns annotation on prod ingress-nginx
* this will result in production discourse swapping dns to new cluster.

Note: this change was discussed and approved earlier today; it is occurring now to target a low traffic period for the switchover.