### PR TITLE
Renaming the django deployment to include the word admin

### DIFF
--- a/k8s/releases/careers/careers-prod.yaml
+++ b/k8s/releases/careers/careers-prod.yaml
@@ -34,7 +34,7 @@ spec:
         name: prod
         prod: https://acme-v02.api.letsencrypt.org/directory
       hosts:
-      - host: careers.prod.mozit.cloud
+      - host: careers-admin.prod.mozit.cloud
         paths:
         - path: /
           backend:
@@ -43,5 +43,5 @@ spec:
       name: careers
       tls:
       - hosts:
-        - careers.prod.mozit.cloud
+        - careers-admin.prod.mozit.cloud
         secretName: cert-careers-prod-mozit-cloud

--- a/k8s/workloads/careers/careers-ingress-prod.yaml
+++ b/k8s/workloads/careers/careers-ingress-prod.yaml
@@ -53,7 +53,7 @@ spec:
           service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
           service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled: "true"
           service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: "Environment=prod"
-          external-dns.alpha.kubernetes.io/hostname: "careers.prod.mozit.cloud"
+          external-dns.alpha.kubernetes.io/hostname: "careers-admin.prod.mozit.cloud"
     rbac:
       create: true
       scope: true


### PR DESCRIPTION
To clear space for the rendered static site to live at careers.prod.mozit.cloud