### PR TITLE
securitywiki EFS security group updates

### DIFF
--- a/terraform/applications/securitywiki/efs.tf
+++ b/terraform/applications/securitywiki/efs.tf
@@ -7,7 +7,7 @@ resource "aws_efs_mount_target" "securitywiki" {
   file_system_id = aws_efs_file_system.securitywiki.id
   subnet_id      = tolist(flatten([data.terraform_remote_state.vpc.outputs.private_subnets]))[count.index]
   security_groups = [
-    data.terraform_remote_state.k8s.outputs.worker_security_group_id,
+    data.terraform_remote_state.k8s.outputs.cluster_primary_security_group_id,
     "sg-083a35a6d382d52dc", # old cluster
     "sg-0b9bcd2ae46fe0792"  # old cluster
   ]

--- a/terraform/shared/outputs.tf
+++ b/terraform/shared/outputs.tf
@@ -10,6 +10,10 @@ output "cluster_name" {
   value = module.itse-apps-prod-1.cluster_id
 }
 
+output "cluster_primary_security_group_id" {
+  value = module.itse-apps-stage-1.cluster_primary_security_group_id
+}
+
 output "cluster_worker_iam_role_arn" {
   value = module.itse-apps-prod-1.worker_iam_role_arn
 }


### PR DESCRIPTION
Jira: https://mozilla-hub.atlassian.net/browse/SE-2159

What this PR does:
* updates SecurityWiki EFS to be in the primary eks security group, not the ("additional") eks security group
* fixes SecurityWiki pods talking to EFS over a NFS network connection

Note:
* came up in repairing this - the manually added old security group ids will be removed once this app is migrated
* tagging @duallain on this since he paired with me on it, but happy to walk anyone through what is going on here