### PR TITLE
add prod securitywiki ns, app release, ingress-nginx release

### DIFF
--- a/k8s/namespaces/securitywiki-prod.yaml
+++ b/k8s/namespaces/securitywiki-prod.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: securitywiki-prod

--- a/k8s/releases/securitywiki/securitywiki.yaml
+++ b/k8s/releases/securitywiki/securitywiki.yaml
@@ -1,0 +1,87 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: securitywiki
+  namespace: securitywiki-prod
+  labels:
+    app: securitywiki
+  annotations:
+    fluxcd.io/automated: "true"
+    filter.fluxcd.io/chart-image: regex:^(v[0-9]+.[0-9]+.[0-9]+)$
+spec:
+  releaseName: securitywiki
+  chart:
+    repository: https://mozilla-it.github.io/helm-charts/
+    name: securitywiki
+    version: "1.0.0"
+  values:
+    configMap:
+      data:
+        ENVIRONMENT: prod
+        MEMCACHED_PORT: "11211"
+        MYSQL_DATABASE: securitywiki
+        MYSQL_USER: securitywiki
+        SITE_URL: https://securitywiki.mozilla.org
+    deployment:
+      replicaCount: "1"
+    externalSecrets:
+      enabled: true
+      name: securitywiki
+      secrets:
+      - key: /prod/securitywiki/envvar
+        name: MEMCACHED_HOST
+        property: MEMCACHED_HOST
+      - key: /prod/securitywiki/envvar
+        name: MYSQL_HOST
+        property: MYSQL_HOST
+      - key: /prod/securitywiki/envvar
+        name: MYSQL_PASSWORD
+        property: MYSQL_PASSWORD
+      - key: /prod/securitywiki/envvar
+        name: OIDC_CLIENT_ID
+        property: OIDC_CLIENT_ID
+      - key: /prod/securitywiki/envvar
+        name: OIDC_CLIENT_SECRET
+        property: OIDC_CLIENT_SECRET
+      - key: /prod/securitywiki/envvar
+        name: OIDC_CRYPTO_PASSPHRASE
+        property: OIDC_CRYPTO_PASSPHRASE
+    hpa:
+      enabled: false
+    image:
+      pullPolicy: Always
+      repository: 783633885093.dkr.ecr.us-west-2.amazonaws.com/securitywiki
+      tag: v1.0.0
+    ingress:
+      hosts:
+      - host: securitywiki.prod.mozit.cloud
+        paths:
+        - path: /
+          pathType: ImplementationSpecific
+          serviceName: securitywiki
+          servicePort: 80
+      - host: securitywiki.mozilla.org
+        paths:
+        - path: /
+          pathType: ImplementationSpecific
+          serviceName: securitywiki
+          servicePort: 80
+      le:
+        name: prod
+      name: securitywiki
+      tls:
+      - hosts:
+        - securitywiki.mozilla.org
+        secretName: cert-securitywiki-mozilla-org
+      - hosts:
+        - securitywiki.prod.mozit.cloud
+        secretName: cert-securitywiki-prod-mozit-cloud
+    volume:
+      accessModes: ReadWriteMany
+      capacityStorage: 100Gi
+      create: true
+      name: securitywiki-prod
+      nfsServer: "fs-d663987c.efs.us-west-2.amazonaws.com"
+      storageClassName: efs
+      storageRequest: 20Gi

--- a/k8s/workloads/securitywiki/securitywiki-ingress.yaml
+++ b/k8s/workloads/securitywiki/securitywiki-ingress.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: ingress-nginx
+  namespace: securitywiki-prod
+  labels:
+    app: securitywiki
+spec:
+  releaseName: securitywiki-ingress-nginx
+  chart:
+    repository: https://kubernetes.github.io/ingress-nginx
+    name: ingress-nginx
+    version: "3.33.0"
+  values:
+    controller:
+      useIngressClassOnly: true
+      enableCustomResources: false
+      autoscaling:
+        enabled: true
+        minReplicas: 1
+        maxReplicas: 4
+        targetCPUUtilizationPercentage: 80
+        targetMemoryUtilizationPercentage: 80
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          cpu: 200m
+          memory: 256Mi
+      admissionWebhooks:
+        enable: false
+      scope:
+        enabled: true
+      config:
+        use-proxy-protocol: "false"
+        use-forwarded-headers: "true"
+        # restrict this to the IP addresses of ELB
+        proxy-real-ip-cidr: "0.0.0.0/0"
+      service:
+        externalTrafficPolicy: "Local"
+        annotations:
+          service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+          service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
+          service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled: "true"
+          service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: "Environment=prod"
+          external-dns.alpha.kubernetes.io/hostname: "securitywiki.prod.mozit.cloud,securitywiki.mozilla.org"
+      metrics:
+        enabled: true
+        service:
+          annotations:
+            prometheus.io/scrape: "true"
+            prometheus.io/port: "10254"
+    rbac:
+      create: true
+      scope: true

--- a/k8s/workloads/securitywiki/securitywiki-ingress.yaml
+++ b/k8s/workloads/securitywiki/securitywiki-ingress.yaml
@@ -45,7 +45,7 @@ spec:
           service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
           service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled: "true"
           service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: "Environment=prod"
-          external-dns.alpha.kubernetes.io/hostname: "securitywiki.prod.mozit.cloud,securitywiki.mozilla.org"
+          external-dns.alpha.kubernetes.io/hostname: "securitywiki.prod.mozit.cloud"
       metrics:
         enabled: true
         service:


### PR DESCRIPTION
Jira: https://mozilla-hub.atlassian.net/browse/SE-2161

What this PR does:
* adds k8s config for securitywiki prod namespace
* adds helmrelease for securitywiki prod ingress-nginx
* adds helmrelease for securitywiki prod application helm release (blocked by helm release pr)

Blocked by: https://github.com/mozilla-it/helm-charts/pull/120