### PR TITLE
make discourse logger config a templated secret

### DIFF
--- a/k8s/releases/discourse/discourse.yaml
+++ b/k8s/releases/discourse/discourse.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     repository: https://mozilla-it.github.io/helm-charts/
     name: discourse
-    version: "2.0.0"
+    version: "2.0.1"
   values:
     configMap:
       data:

--- a/k8s/releases/discourse/discourse.yaml
+++ b/k8s/releases/discourse/discourse.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     repository: https://mozilla-it.github.io/helm-charts/
     name: discourse
-    version: "0.0.1"
+    version: "2.0.0"
   values:
     configMap:
       data:
@@ -50,6 +50,7 @@ spec:
       arn_role: arn:aws:iam::783633885093:role/discourse/discourse-prod
     externalSecrets:
       enabled: true
+      loggerSecretKey: /prod/discourse/logger
       name: discourse
       secrets:
       - key: /prod/discourse/envvar

--- a/terraform/applications/discourse/cdn.tf
+++ b/terraform/applications/discourse/cdn.tf
@@ -11,19 +11,6 @@ resource "aws_cloudfront_distribution" "discourse" {
   ]
 
   origin {
-    domain_name = var.discourse_cdn_zone
-    origin_id   = "discourse-pull-origin-old"
-    origin_path = ""
-
-    custom_origin_config {
-      http_port              = "80"
-      https_port             = "443"
-      origin_protocol_policy = "https-only" # Only talk to the origin over HTTPS
-      origin_ssl_protocols   = ["TLSv1", "TLSv1.1", "TLSv1.2"]
-    }
-  }
-
-  origin {
     domain_name = "discourse.${var.environment}.mozit.cloud"
     origin_id   = "discourse-pull-origin"
     origin_path = ""

--- a/terraform/applications/discourse/secrets.tf
+++ b/terraform/applications/discourse/secrets.tf
@@ -4,3 +4,8 @@ resource "aws_secretsmanager_secret" "envvar" {
   name        = "/${var.environment}/discourse/envvar"
   description = "discourse ${var.environment} environment variables as json (see helm chart for expected json)"
 }
+
+resource "aws_secretsmanager_secret" "logger" {
+  name        = "/${var.environment}/discourse/logger"
+  description = "discourse ${var.environment} papertrail logger configuration as json (see helm chart for expected json)"
+}


### PR DESCRIPTION
Jira: https://mozilla-hub.atlassian.net/browse/SE-2173 

What this PR does:
* replaces the hard-coded logger config ConfigMap template with an ExternalSecrets setup (update discourse helm chart, add secret metadata to terraform for discourse prod logger secret)
* came up in decommissioning https://github.com/mozilla-it/discourse-infra

Related to: https://github.com/mozilla-it/helm-charts/pull/121 & https://github.com/mozilla-it/itse-apps-stage-1-infra/pull/107
