### PR TITLE
migrate mozilla-redirects.xyz zone from old cluster tf to here

### DIFF
--- a/terraform/shared/main.tf
+++ b/terraform/shared/main.tf
@@ -71,3 +71,24 @@ resource "aws_eip" "refractr_eip" {
     App      = "refractr"
   }
 }
+
+# Uncertain if we still *need* this domain
+# but migrating it here from itsre apps repo
+resource "aws_route53_delegation_set" "delegation_set" {
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_zone" "mozilla-redirects" {
+  name = "mozilla-redirects.xyz"
+
+  delegation_set_id = aws_route53_delegation_set.delegation_set.id
+
+  tags = {
+    Name      = "mozilla-redirects.xyz"
+    Purpose   = "mozilla redirects master zone"
+    Terraform = "true"
+  }
+}
+


### PR DESCRIPTION
Jira: came up in https://mozilla-hub.atlassian.net/browse/SE-1057

What this PR does:
- migrates mozilla-redirects.xyz from itsre-apps repo's tf to here
- uncertain we want mozilla-redirects.xyz, but leaving that work to a general refractr cleanup effort