### PR TITLE
add a backups s3 bucket to shared infra

### DIFF
--- a/terraform/shared/backups.tf
+++ b/terraform/shared/backups.tf
@@ -1,0 +1,18 @@
+# These resources support a cross-Web SRE place to store backups.
+# These backups, like for SubHub, are pulled from AWS Accounts or services that have been decommissioned,
+# but we wanted to keep some artifact(s) around in case.
+
+resource "aws_s3_bucket" "backups" {
+  bucket = "websre-backups"
+  acl    = "private"
+
+  lifecycle_rule {
+    id      = "purge_tombstone"
+    enabled = true
+    prefix  = "tombstone/"
+
+    expiration {
+      days = 30
+    }
+  }
+}


### PR DESCRIPTION
Jira: https://mozilla-hub.atlassian.net/browse/SE-2192

What this PR does:
- adds a websre-backups s3 bucket, to be used for storing backups or other data artifacts from closed AWS accounts
- this bucket should contain, as one example, the subhub dynamodb table backups (exports)