### PR TITLE
refractr: add 2 new LE wildcard cert domains to DNS01 issuer

### DIFF
--- a/k8s/releases/refractr/refractr.yaml
+++ b/k8s/releases/refractr/refractr.yaml
@@ -33,6 +33,8 @@ spec:
         - phish-report.mozilla.com
         - '*.phish-report.mozilla.com'
         - '*.www.mozilla.com'
+        - '*.add-ons.mozilla.com'
+        - '*.add-ons.mozilla.org'
         hostedZoneID: Z06469063HC60S7SHF706
     environment: prod
     refractr:


### PR DESCRIPTION
Jira: https://mozilla-hub.atlassian.net/browse/SE-2688

What this PR does:
* wildcard mapping in Nginx => wilcard cert in Refractr => LE wildcard order => required LE Issuer to use DNS01 Challenge for these domains
* wildcard mappings required for ticket above & domains *.add-ons.mozilla.org & *.add-ons.mozilla.com
* Haven't switched DNS records yet, just getting this setup