### PR TITLE
refractr: add DNS lookup for foxfooding.mozilla.community

### DIFF
--- a/k8s/releases/refractr/refractr.yaml
+++ b/k8s/releases/refractr/refractr.yaml
@@ -35,6 +35,7 @@ spec:
         - '*.www.mozilla.com'
         - '*.add-ons.mozilla.com'
         - '*.add-ons.mozilla.org'
+        - foxfooding.mozilla.community
         hostedZoneID: Z06469063HC60S7SHF706
     environment: prod
     refractr:


### PR DESCRIPTION
Jira: https://mozilla-hub.atlassian.net/browse/SE-2447

What this PR does:
- adds foxfooding.mozilla.community to refractr DNS01 challenges

Why this PR:
- foxfooding.mozilla.community was requested to be pointed somewhere new a few months ago
- however, it was already in refractr as a 301, so the redirect was cached by some browsers, hence having it stay in refractr (for cached clients) & point to heroku (for new clients)
- we're adding a DNS01 challenge so we can renew the Refractr cert so the cached clients can still successfully get to the correct endpoint without changing the heroku dns. after this cert expires, we plan to remove the foxfooding _refractr_ cert & remove the redirect from refractr entirely (hoping then cached clients will have expired for this particular domain)