### PR TITLE
decom library.mozilla.org [SE-2713]

### DIFF
--- a/k8s/releases/telegraf/telegraf.yaml
+++ b/k8s/releases/telegraf/telegraf.yaml
@@ -144,7 +144,6 @@ spec:
               - 'https://leadership.mozilla.community:443'
               - 'https://leandatapractices.com:443'
               - 'https://leandatapractices.org:443'
-              - 'https://library.mozilla.org:443'
               - 'https://lightning-project.org:443'
               - 'https://lockbox.firefox.com:443'
               - 'https://lockwise.firefox.com:443'


### PR DESCRIPTION
The plan of decom here is 1) remove monitoring, 2) remove dns, 3) [remove redirect](https://github.com/mozilla-it/refractr/pull/205). I would like to pair for the deploy process for this change (if any), but it can go live at any time.