### PR TITLE
 Have Discourse's nginx block path /webhooks/aws via ingress annotation #110 

### DIFF
--- a/k8s/releases/discourse/discourse.yaml
+++ b/k8s/releases/discourse/discourse.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     repository: https://mozilla-it.github.io/helm-charts/
     name: discourse
-    version: "2.0.1"
+    version: "2.0.2"
   values:
     configMap:
       data:
@@ -97,6 +97,11 @@ spec:
       repository: 783633885093.dkr.ecr.us-west-2.amazonaws.com/discourse
       tag: prod-v1.0.0
     ingress:
+      annotations:
+        nginx.ingress.kubernetes.io/server-snippet: |
+              location /webhooks/aws {
+                deny all;
+              }
       hosts:
       - host: discourse.prod.mozit.cloud
         paths:


### PR DESCRIPTION
Bugzilla: https://bugzilla.mozilla.org/show_bug.cgi?id=1737346

What this PR does:
* add annotation to Discourse prod ingress to block /webhooks/aws per: https://github.com/discourse/discourse/security/advisories/GHSA-jcjx-pvpc-qgwq 
* is currently manually applied in prod, updated configs to match
* will also rotate all secrets after this, as it leaked all discourse secrets