### PR TITLE
chore(refractr): Add webxr.today to expected DNS

### DIFF
--- a/k8s/releases/refractr/refractr.yaml
+++ b/k8s/releases/refractr/refractr.yaml
@@ -36,6 +36,7 @@ spec:
         - '*.add-ons.mozilla.com'
         - '*.add-ons.mozilla.org'
         - foxfooding.mozilla.community
+        - webxr.today
         hostedZoneID: Z06469063HC60S7SHF706
     environment: prod
     refractr:


### PR DESCRIPTION
We want to try this method of cutting over without any downtime. https://mana.mozilla.org/wiki/pages/viewpage.action?spaceKey=SRE&title=Refractr+-+How+To+-+DNS+Challenges

DNS is already configured.

```bash
$ dig +short  _acme-challenge.webxr.today
_acme-challenge.prod.refactr.mozit.cloud.
```