### PR TITLE
Revert "discourse: Use latest version of Helm chart, matching stage"

### DIFF
--- a/k8s/releases/discourse/discourse.yaml
+++ b/k8s/releases/discourse/discourse.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     repository: https://mozilla-it.github.io/helm-charts/
     name: discourse
-    version: "3.0.5"
+    version: "2.0.2"
   values:
     autoscaling:
       minReplicas: 10


### PR DESCRIPTION
Reverts mozilla-it/itse-apps-prod-1-infra#108

The prod environment does not yet have the external secrets operator required by the new release, so we are reverting back to the old version.