### PR TITLE
chore: update discourse helm chart

### DIFF
--- a/k8s/releases/discourse/discourse.yaml
+++ b/k8s/releases/discourse/discourse.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     repository: https://mozilla-it.github.io/helm-charts/
     name: discourse
-    version: "2.0.2"
+    version: "3.0.6"
   values:
     autoscaling:
       minReplicas: 10


### PR DESCRIPTION
I updated the helm secret for the previous version so this should be good to go. I need to do a manual upgrade at the same time.