### PR TITLE
chore(dockerhub): Adding credentials for a user to assist with image …

### DIFF
--- a/k8s/releases/discourse/discourse.yaml
+++ b/k8s/releases/discourse/discourse.yaml
@@ -113,6 +113,8 @@ spec:
       pullPolicy: Always
       repository: 783633885093.dkr.ecr.us-west-2.amazonaws.com/discourse
       tag: prod-v1.0.0
+    imagePullSecrets:
+      - name: dockerhub-credentials
     ingress:
       annotations:
         nginx.ingress.kubernetes.io/server-snippet: |

--- a/k8s/releases/etherpad/etherpad.yaml
+++ b/k8s/releases/etherpad/etherpad.yaml
@@ -46,6 +46,8 @@ spec:
       pullPolicy: Always
       repository: 783633885093.dkr.ecr.us-west-2.amazonaws.com/etherpad
       tag: v1.0.1
+    imagePullSecrets:
+      - name: dockerhub-credentials
     ingress:
       hosts:
       - host: pad.mozilla.org

--- a/k8s/releases/moderator/moderator.yaml
+++ b/k8s/releases/moderator/moderator.yaml
@@ -62,6 +62,8 @@ spec:
       pullPolicy: Always
       repository: 783633885093.dkr.ecr.us-west-2.amazonaws.com/moderator
       tag: v2.0.6
+    imagePullSecrets:
+      - name: dockerhub-credentials
     ingress:
       hosts:
       - host: moderator.prod.mozit.cloud

--- a/k8s/releases/pastebin/pastebin.yaml
+++ b/k8s/releases/pastebin/pastebin.yaml
@@ -47,6 +47,8 @@ spec:
       pullPolicy: Always
       repository: 783633885093.dkr.ecr.us-west-2.amazonaws.com/pastebin
       tag: v3.5.8
+    imagePullSecrets:
+      - name: dockerhub-credentials
     ingress:
       hosts:
       - host: paste.prod.mozit.cloud


### PR DESCRIPTION
…pull back off errors

It looks like these are already available in the helm-charts just never used. I created the login, stored the value in 1pass and created the secrets.